### PR TITLE
Fixing Polymer version for Bower install

### DIFF
--- a/demo-management-tools/bower.json
+++ b/demo-management-tools/bower.json
@@ -19,7 +19,7 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "polymer#~0.4.0",
+    "polymer": "polymer#~0.3.6",
     "paper-elements": "Polymer/paper-elements#~0.3.4",
     "core-ajax": "Polymer/core-ajax#~0.3.4"
   }


### PR DESCRIPTION
All components must be 3.x versions currently.
